### PR TITLE
Add README documentation for software examples

### DIFF
--- a/C/README.md
+++ b/C/README.md
@@ -1,0 +1,97 @@
+# C Language SLURM Job Examples for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains example SLURM submission scripts for compiling and running C programs on Roar Collab. The examples demonstrate serial execution, OpenMP multi-threading, and MPI parallelization.
+
+## Files
+
+- `demo_c_serial.c` - Serial C program
+- `demo_c_openmp.c` - C program using OpenMP for shared-memory parallelization
+- `demo_c_mpi.c` - C program using MPI for distributed-memory parallelization
+- `serial.slurm` - SLURM script for serial execution
+- `openmp.slurm` - SLURM script for OpenMP execution
+- `mpi.slurm` - SLURM script for MPI execution
+
+## How to Run
+
+### Serial Job
+```bash
+sbatch serial.slurm
+```
+
+### OpenMP Parallel Job
+```bash
+sbatch openmp.slurm
+```
+
+### MPI Parallel Job
+```bash
+sbatch mpi.slurm
+```
+
+## Script Breakdown
+
+### serial.slurm
+```bash
+#!/bin/bash
+#SBATCH --mem-per-cpu=1024                 # Allocate 1024 MB per CPU
+#SBATCH --ntasks=1                         # Run 1 task
+#SBATCH --time=00:01:00                    # Allocate 1 minute of wall time
+#SBATCH --job-name=serial                  # Name of the job
+#SBATCH --error=serial.%J.err              # Error log
+#SBATCH --output=serial.%J.out             # Output log
+
+module load gcc                             # Load GCC compiler
+
+gcc demo_c_serial.c -o demo_c_serial        # Compile the program
+./demo_c_serial                             # Run the program
+rm demo_c_serial                            # Clean up executable
+```
+
+### openmp.slurm
+```bash
+#!/bin/bash
+#SBATCH --mem-per-cpu=1024                 # Allocate 1024 MB per CPU
+#SBATCH --ntasks=1                         # Run 1 task
+#SBATCH --time=00:01:00                    # Allocate 1 minute
+#SBATCH --job-name=openmp                  # Name of the job
+#SBATCH --error=openmp.%J.err              # Error log
+#SBATCH --output=openmp.%J.out             # Output log
+
+module load gcc                             # Load GCC compiler
+
+gcc -fopenmp demo_c_openmp.c -o demo_c_openmp  # Compile with OpenMP support
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK   # Set OpenMP threads
+./demo_c_openmp                             # Run the program
+rm demo_c_openmp                            # Clean up executable
+```
+
+### mpi.slurm
+```bash
+#!/bin/bash
+#SBATCH --mem-per-cpu=1024                 # Allocate 1024 MB per CPU
+#SBATCH --ntasks=5                         # Run 5 MPI tasks
+#SBATCH --time=00:01:00                    # Allocate 1 minute
+#SBATCH --job-name=mpi                     # Name of the job
+#SBATCH --error=mpi.%J.err                 # Error log
+#SBATCH --output=mpi.%J.out                # Output log
+
+module load openmpi/4.1.1-pmi2              # Load OpenMPI library
+
+mpicc demo_c_mpi.c -o demo_c_mpi           # Compile with MPI support
+mpirun -np 5 ./demo_c_mpi                  # Run with 5 MPI processes
+rm demo_c_mpi                               # Clean up executable
+```
+
+## Notes
+
+- **Serial**: Uses GCC to compile and run a simple C program
+- **OpenMP**: Enables shared-memory parallelization using compiler flags (`-fopenmp`). All threads share the same memory
+- **MPI**: Enables distributed-memory parallelization where each process has its own memory and communicates via message passing
+- `mpicc` is the MPI C compiler wrapper that automatically includes necessary MPI libraries
+- `mpirun` launches MPI processes across allocated nodes
+- Choose the appropriate parallelization method based on your problem:
+  - Serial: Single-threaded execution
+  - OpenMP: Multi-core on a single node (shared memory)
+  - MPI: Multiple nodes or fine-grained control over communication

--- a/ansys/README.md
+++ b/ansys/README.md
@@ -1,0 +1,67 @@
+# ANSYS SLURM Job Examples for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains example SLURM submission scripts for running ANSYS jobs on Roar Collab. ANSYS is a comprehensive finite element analysis (FEA) software suite used for structural analysis, computational fluid dynamics (CFD), and electromagnetic simulations.
+
+## Files
+
+- `ansys.submit` - Serial ANSYS job example with job array capability
+- `ansys-mpi.submit` - MPI-parallel ANSYS job example
+- `example.inp` - Sample ANSYS input file
+
+## How to Run
+
+### Serial Job with Job Arrays
+
+Submit the serial job with:
+```bash
+qsub ansys.submit
+```
+
+For checking job status:
+```bash
+qstat -f <job_id>
+```
+
+### MPI Parallel Job
+
+Submit the MPI job with:
+```bash
+qsub ansys-mpi.submit
+```
+
+## Script Breakdown
+
+### ansys.submit
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1                          # Use 1 compute node
+#SBATCH --ntasks-per-node=1                # Run 1 task per node
+#SBATCH --time=10:00                       # Allocate 10 minutes of wall time
+#SBATCH --mem=2gb                          # Allocate 2 GB of memory
+#SBATCH --account=test_credits_iask        # Charge to this account
+#SBATCH --partition=himem                  # Use high memory partition
+#SBATCH --output=ansys.%j.%a.out           # Output log (j=job_id, a=array_index)
+#SBATCH --error=ansys.%j.%a.err            # Error log
+#SBATCH --array=1-100                      # Create 100 array jobs
+
+module load ansys/2023R2                   # Load ANSYS version 2023 R2
+
+# Create unique input file for each array task
+cp example.inp example.$SLURM_JOB_ID.$SLURM_ARRAY_TASK_ID.inp
+
+# Run ANSYS in batch mode
+ansys232 -b \                               # Run ANSYS in batch mode (no GUI)
+         -np $SLURM_NTASKS \               # Use number of processors
+         -i example.$SLURM_JOB_ID.$SLURM_ARRAY_TASK_ID.inp \  # Input file
+         -o example.$(hostname).$SLURM_JOB_ID.$SLURM_ARRAY_TASK_ID.out  # Output file
+```
+
+## Notes
+
+- The `#SBATCH --array=1-100` directive creates 100 parallel job array tasks, useful for parameter sweeps
+- Each array task gets its own unique input and output files to prevent conflicts
+- The `himem` partition provides high-memory nodes suitable for large ANSYS simulations
+- Modify the input file `example.inp` with your own ANSYS commands

--- a/bash/parslurm/README.md
+++ b/bash/parslurm/README.md
@@ -1,0 +1,55 @@
+# Bash Parallel SLURM Job Example for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains an example of running parallel bash commands using SLURM on Roar Collab. The `srun` command is used to launch tasks across multiple nodes, demonstrating basic parallel job execution.
+
+## Files
+
+- `parjob.slurm` - SLURM submission script for parallel bash execution
+- `simplecheck.sh` - Simple bash script that runs on each parallel task
+
+## How to Run
+
+Submit the job with:
+```bash
+sbatch parjob.slurm
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+## Script Breakdown
+
+### parjob.slurm
+
+```bash
+#!/bin/bash
+
+#SBATCH --job-name=parallel_example        # Name of the job
+#SBATCH --account=open                     # Use open account
+#SBATCH --partition=open                   # Use open partition
+#SBATCH --nodes=4-4                        # Request exactly 4 nodes
+#SBATCH --ntasks-per-node=2                # Run 2 tasks on each node (8 total)
+#SBATCH --mem-per-cpu=100mb                # Allocate 100 MB per CPU
+#SBATCH --time=00:01:00                    # Allocate 1 minute of wall time
+#SBATCH --output=%x.%j.out                 # Output log (x=job_name, j=job_id)
+#SBATCH --error=%x.%j.err                  # Error log
+
+srun -l bash simplecheck.sh                # Launch bash script on all tasks
+                                           # -l flag labels output with task ID
+```
+
+### simplecheck.sh
+
+This script runs on each parallel task. The `-l` flag in `srun` prepends each line of output with the task ID, making it easy to track which node/task produced the output.
+
+## Notes
+
+- `srun` is used to launch tasks across allocated resources in parallel
+- The `-l` flag labels each output line with the task/node ID for easy tracking
+- `--nodes=4-4` means request exactly 4 nodes (4 minimum and 4 maximum)
+- Total number of parallel tasks = 4 nodes × 2 tasks per node = 8 parallel tasks
+- This is useful for embarrassingly parallel workloads or running independent analyses in parallel

--- a/blast/README.md
+++ b/blast/README.md
@@ -1,0 +1,73 @@
+# BLAST SLURM Job Example for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains an example SLURM submission script for running BLAST (Basic Local Alignment Search Tool) on Roar Collab. BLAST is a widely used bioinformatics tool for comparing biological sequences.
+
+## Files
+
+- `blast_aa_multi.slurm` - SLURM submission script for parallel BLAST sequence alignment
+- `yeast.aa` - FASTA file containing yeast amino acid sequences (database)
+- `yeast.aa.fasta` - FASTA file containing query sequences for BLAST search
+
+## How to Run
+
+Submit the job with:
+```bash
+sbatch blast_aa_multi.slurm
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+Monitor output:
+```bash
+tail -f blast_aa_multi.alignments
+```
+
+## Script Breakdown
+
+### blast_aa_multi.slurm
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1                          # Use 1 compute node
+#SBATCH --ntasks-per-node=2                # Allocate 2 processors on the node
+#SBATCH --mem=5gb                          # Allocate 5 GB of memory
+#SBATCH --time=00:10:00                    # Allocate 10 minutes of wall time
+#SBATCH --job-name=blast_aa_multi          # Name of the job
+#SBATCH --error=blast.aa.multi.%J.err      # Error log (J=job_id)
+#SBATCH --output=blast.aa.multi.%J.out     # Output log
+
+module purge                                # Clear any existing modules
+module load blast                           # Load BLAST module
+
+# Copy input files to scratch directory for faster I/O
+cp yeast.aa ~/scratch
+cp yeast.aa.fasta ~/scratch
+
+# Create BLAST database from the FASTA file
+makeblastdb -in ~/scratch/yeast.aa \       # Input database file
+            -dbtype prot \                  # Database type is protein sequences
+            -out ~/scratch/yeast.aa.db      # Output database name
+
+# Run BLAST search with multi-threaded support
+blastp -db ~/scratch/yeast.aa.db \         # Use the created database
+       -query ~/scratch/yeast.aa.fasta \   # Query sequence file
+       -out ~/scratch/blast_aa_multi.alignments \  # Output alignments file
+       -num_threads $SLURM_NTASKS_PER_NODE  # Use 2 threads for parallel search
+
+# Copy results back to job directory
+cp ~/scratch/blast_aa_multi.alignments .
+```
+
+## Notes
+
+- Files are copied to `~/scratch` for faster I/O during processing (scratch is optimized for fast I/O)
+- `makeblastdb` creates a searchable database from the subject sequences
+- `blastp` performs protein-protein BLAST searches
+- The `-num_threads` parameter enables multi-threaded execution for faster searches
+- Output alignments are copied back to the current directory for easy access
+- Modify `yeast.aa` and `yeast.aa.fasta` with your own sequence data

--- a/comsol/README.md
+++ b/comsol/README.md
@@ -1,0 +1,53 @@
+# COMSOL SLURM Job Example for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains an example SLURM submission script for running COMSOL Multiphysics on Roar Collab. COMSOL is a finite element analysis (FEA) software used for simulating physics and engineering applications.
+
+## Files
+
+- `comsol.slurm` - SLURM submission script for COMSOL batch execution
+- `effective_diffusivity.mph` - Sample COMSOL model file
+
+## How to Run
+
+Submit the job with:
+```bash
+sbatch comsol.slurm
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+## Script Breakdown
+
+### comsol.slurm
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1                          # Use 1 compute node
+#SBATCH --ntasks-per-node=1                # Run 1 task per node
+#SBATCH --time=10:00:00                    # Allocate 10 hours of wall time
+#SBATCH --mem=20gb                         # Allocate 20 GB of memory
+#SBATCH --account=test_credits_iask        # Charge to this account
+#SBATCH --partition=himem                  # Use high-memory partition
+#SBATCH --output=comsol.%J.out             # Output log
+#SBATCH --error=comsol.%J.err              # Error log
+
+module load comsol                          # Load COMSOL module
+
+# Run COMSOL in batch mode (non-interactive)
+comsol batch -inputfile effective_diffusivity.mph  # Input COMSOL model file
+```
+
+## Notes
+
+- COMSOL requires significant memory; adjust `--mem` based on your model complexity
+- The `comsol batch` command runs COMSOL in non-interactive mode, suitable for HPC clusters
+- Use the COMSOL GUI on your local machine to create and test the model file (`.mph`)
+- Transfer the tested model file to Roar and submit it for batch processing
+- The `himem` partition is recommended for large COMSOL simulations
+- Wall time requirement depends on model complexity; adjust `--time` accordingly
+- Output files will be generated in the model's output directory (typically defined within the `.mph` file)

--- a/conda/README.md
+++ b/conda/README.md
@@ -1,0 +1,88 @@
+# Conda Environment SLURM Job Example for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains an example SLURM submission script for running Python code with a Conda environment on Roar Collab. This example demonstrates environment creation, activation, and running Python scripts within a managed dependency environment.
+
+## Files
+
+- `conda_plot_lib.submit` - SLURM submission script that manages conda environment
+- `conda_plot_lib_create_env.sh` - Bash script to create the conda environment
+- `conda_plot_lib_example.py` - Python script that uses libraries from the conda environment
+
+## How to Run
+
+Submit the job with:
+```bash
+sbatch conda_plot_lib.submit
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+View results:
+```bash
+cat conda_plot_lib.*.out
+```
+
+## Script Breakdown
+
+### conda_plot_lib.submit
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1                          # Use 1 compute node
+#SBATCH --ntasks-per-node=1                # Run 1 task per node
+#SBATCH --mem=4gb                          # Allocate 4 GB of memory
+#SBATCH --time=00:10:00                    # Allocate 10 minutes
+#SBATCH --job-name=conda_plot_lib          # Name of the job
+#SBATCH --error=conda_plot_lib.%J.err      # Error log
+#SBATCH --output=conda_plot_lib.%J.out     # Output log
+
+module purge                                # Clear all existing modules
+module load anaconda3                       # Load Anaconda Python
+
+# Initialize conda
+source ~/.bashrc                            # Source bashrc to set up conda
+conda init bash                             # Initialize bash for conda
+
+# Check if the environment already exists, create if it doesn't
+if conda env list | grep -q "test_env"; then
+    echo "Conda environment 'test_env' already exists."
+else
+    echo "Conda environment 'test_env' does not exist. Creating..."
+    bash conda_plot_lib_create_env.sh       # Run script to create the environment
+fi
+
+# Activate the conda environment
+echo "Activating test_env"
+conda activate test_env
+
+# Run your Python script
+echo "Running conda plot example"
+python conda_plot_lib_example.py            # Execute the Python script
+
+echo "Done"
+```
+
+### conda_plot_lib_create_env.sh
+
+This script typically contains:
+```bash
+#!/bin/bash
+conda create -n test_env python=3.10 numpy matplotlib pandas -y
+```
+
+This creates a conda environment named `test_env` with Python 3.10 and popular libraries.
+
+## Notes
+
+- The script checks if the conda environment exists before creating it, avoiding redundant creation
+- Conda environments are persistent across job submissions, so creation happens only once
+- Always `module purge` before loading anaconda to avoid module conflicts
+- `source ~/.bashrc` initializes the conda setup in your environment
+- Modify `conda_plot_lib_create_env.sh` to install the specific packages your code requires
+- Conda environments are stored in `~/.conda/envs/` by default
+- This approach is cleaner than using `pip install` in every job submission

--- a/fluent/README.md
+++ b/fluent/README.md
@@ -1,0 +1,85 @@
+# ANSYS Fluent SLURM Job Examples for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains example SLURM submission scripts for running ANSYS Fluent (Computational Fluid Dynamics software) on Roar Collab. The examples demonstrate both serial and MPI parallel execution.
+
+## Files
+
+- `fluent.slurm` - Serial Fluent job example
+- `fluent-mpi.slurm` - MPI parallel Fluent job example
+- `in.file` - Fluent input journal file
+- `inlet.cas` - Fluent case file
+- `inlet.dat` - Fluent data file
+
+## How to Run
+
+### Serial Job
+```bash
+sbatch fluent.slurm
+```
+
+### MPI Parallel Job
+```bash
+sbatch fluent-mpi.slurm
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+## Script Breakdown
+
+### fluent.slurm (Serial)
+
+```bash
+#!/bin/bash
+#SBATCH --ntasks=1                         # Run 1 task (serial)
+#SBATCH --nodes=1                          # Use 1 node
+#SBATCH --time=10:00:00                    # Allocate 10 hours
+#SBATCH --mem-per-cpu=4gb                  # Allocate 4 GB per CPU
+#SBATCH --error=fluent.%J.err              # Error log
+#SBATCH --output=fluent.%J.out             # Output log
+
+module load ansys                           # Load ANSYS module (includes Fluent)
+
+fluent 2ddp -i in.file -g                   # Run Fluent in 2D double precision
+                                            # -i: input journal file
+                                            # -g: graphics off (batch mode)
+```
+
+### fluent-mpi.slurm (MPI Parallel)
+
+```bash
+#!/bin/bash
+#SBATCH --ntasks=10                        # Run 10 MPI tasks
+#SBATCH --nodes=1                          # Use 1 node (all on same node)
+#SBATCH --time=10:00:00                    # Allocate 10 hours
+#SBATCH --mem-per-cpu=4gb                  # Allocate 4 GB per CPU
+#SBATCH --error=fluent.%J.err              # Error log
+#SBATCH --output=fluent.%J.out             # Output log
+
+module load ansys                           # Load ANSYS module
+
+FLUENTNODES="$(scontrol show hostnames)"   # Get list of allocated nodes
+
+# Run Fluent with MPI parallelization
+fluent 2ddp \                               # 2D, double precision
+       -t${SLURM_NTASKS} \                  # Number of processors (-t = total)
+       -i in.file \                         # Input journal file
+       -cnf=$FLUENTNODES \                  # Node configuration for MPI
+       -g                                   # Graphics off (batch mode)
+```
+
+## Notes
+
+- **2ddp**: Specifies 2D simulation with double precision. Use `3ddp` for 3D or `2d`/`3d` for single precision
+- **Serial**: Use for smaller simulations or debugging
+- **MPI Parallel**: Use for larger simulations requiring distributed computing
+- `-i in.file`: Input file contains journal commands (Fluent commands executed in batch)
+- `-g`: Graphics off flag for batch mode (no GUI)
+- `-cnf=$FLUENTNODES`: Specifies node configuration for MPI jobs; must be used for multi-node jobs
+- Prepare and test your case file (`.cas`) and data file (`.dat`) on your local machine first
+- The input journal file (`in.file`) should contain all commands needed for your simulation
+- Adjust `--ntasks` and wall time based on your simulation complexity and available resources

--- a/fortran/README.md
+++ b/fortran/README.md
@@ -1,0 +1,77 @@
+# Fortran SLURM Job Examples for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains example SLURM submission scripts for compiling and running Fortran programs on Roar Collab. The examples demonstrate both serial and MPI parallel execution.
+
+## Files
+
+- `demo_f_serial.f90` - Serial Fortran program (Fortran 90 syntax)
+- `demo_f_mpi.f90` - MPI parallel Fortran program
+- `submit_serial.slurm` - SLURM script for serial execution
+- `submit_mpi.slurm` - SLURM script for MPI execution
+
+## How to Run
+
+### Serial Job
+```bash
+sbatch submit_serial.slurm
+```
+
+### MPI Parallel Job
+```bash
+sbatch submit_mpi.slurm
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+## Script Breakdown
+
+### submit_serial.slurm
+
+```bash
+#!/bin/bash
+#SBATCH --ntasks=5                         # Number of tasks
+#SBATCH --mem-per-cpu=1024                 # Allocate 1024 MB per CPU
+#SBATCH --time=00:01:00                    # Allocate 1 minute
+#SBATCH --job-name=Fortran                 # Name of the job
+#SBATCH --error=Fortran.%J.err             # Error log
+#SBATCH --output=Fortran.%J.out            # Output log
+
+module load gcc                             # Load GCC compiler (includes gfortran)
+
+gfortran demo_f_serial.f90                  # Compile Fortran 90 program
+./a.out                                     # Run the compiled executable
+```
+
+### submit_mpi.slurm
+
+```bash
+#!/bin/bash
+#SBATCH --ntasks=5                         # Run 5 MPI tasks
+#SBATCH --mem-per-cpu=1024                 # Allocate 1024 MB per CPU
+#SBATCH --time=00:01:00                    # Allocate 1 minute
+#SBATCH --job-name=Fortran_MPI             # Name of the job
+#SBATCH --error=Fortran_MPI.%J.err         # Error log
+#SBATCH --output=Fortran_MPI.%J.out        # Output log
+
+module load openmpi                         # Load OpenMPI library
+module load gcc                             # Load GCC compiler (includes gfortran)
+
+mpif90 demo_f_mpi.f90 -o demo_f_mpi        # Compile Fortran with MPI support
+mpirun -np 5 ./demo_f_mpi                  # Run with 5 MPI processes
+```
+
+## Notes
+
+- **gfortran**: The Fortran compiler from the GCC suite
+- **mpif90**: MPI Fortran compiler wrapper that includes necessary MPI libraries and headers
+- **F90 Format**: Modern Fortran with free-form syntax (as opposed to Fortran 77 fixed-form)
+- **Serial**: Uses `gfortran` for single-process execution
+- **MPI**: Uses `mpif90` to link MPI libraries; `mpirun` launches the processes
+- `-np 5`: Number of MPI processes (must match `--ntasks=5` in SLURM)
+- The compiled executable typically outputs to `a.out` by default
+- For larger Fortran projects, consider using makefiles or build systems like CMake

--- a/gaussian/README.md
+++ b/gaussian/README.md
@@ -1,0 +1,67 @@
+# Gaussian SLURM Job Example for ICDS Roar Collab Cluster
+
+## Overview
+
+This directory contains an example SLURM submission script for running Gaussian (quantum chemistry software) on Roar Collab. Gaussian is used for molecular orbital calculations, thermochemistry, and other quantum mechanics computations.
+
+## Files
+
+- `gaussian-g16.slurm` - SLURM submission script for Gaussian G16
+- `test_g98.com` - Sample Gaussian input file
+
+## How to Run
+
+Submit the job with:
+```bash
+sbatch gaussian-g16.slurm
+```
+
+Check job status:
+```bash
+squeue -j <job_id>
+```
+
+Monitor output:
+```bash
+tail -f test_g98.log
+```
+
+## Script Breakdown
+
+### gaussian-g16.slurm
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=1                          # Use 1 compute node
+#SBATCH --ntasks-per-node=8                # Allocate 8 processors on the node
+#SBATCH --mem=16gb                         # Allocate 16 GB of memory
+#SBATCH --time=24:00:00                    # Allocate 24 hours
+#SBATCH --job-name=gaussian_g16            # Name of the job
+#SBATCH --account=test_credits_iask        # Charge to this account
+#SBATCH --partition=himem                  # Use high-memory partition
+#SBATCH --error=gaussian.%J.err            # Error log
+#SBATCH --output=gaussian.%J.out           # Output log
+
+# Set Gaussian environment variables
+export GAUSS_SCRDIR=/scratch/$USER/$SLURM_JOB_ID  # Temporary scratch directory
+export GAUSS_MDEF=$((SLURM_NTASKS_PER_NODE))      # Number of Gaussian processes
+
+mkdir -p $GAUSS_SCRDIR                     # Create scratch directory
+
+module load gaussian/g16                    # Load Gaussian G16 module
+
+# Run Gaussian on the input file
+g16 test_g98.com                            # Input file (uses test_g98.log for output)
+```
+
+## Notes
+
+- **GAUSS_SCRDIR**: Points to temporary scratch space for intermediate calculations; should be on fast storage
+- **GAUSS_MDEF**: Specifies the number of processes Gaussian will use internally
+- Gaussian creates `.log` output files based on the input filename (e.g., `test_g98.com` → `test_g98.log`)
+- `--ntasks-per-node=8`: Instructs Gaussian to use 8 processors for parallel calculations
+- The `himem` partition is recommended for large molecular systems or high-level of theory calculations
+- Input files (`.com` files) follow Gaussian's input format with route section (`#`), link0 commands, etc.
+- Output includes all quantum chemistry results, orbital energies, geometries, frequencies, etc.
+- Adjust memory (`--mem`) and wall time based on system size and computational level of theory
+- For very large systems, consider multi-node jobs with Linda parallelization (requires additional setup)


### PR DESCRIPTION
Added README files for ansys, bash/parslurm, blast, C, comsol, conda, fluent, fortran, and gaussian directories. Each README includes:
  - Overview of the software
  - List of files in the directory
  - How to run instructions
  - Detailed script breakdown explaining each SLURM directive
  - Notes and recommendations for usage